### PR TITLE
Add Google Docs retrieval action

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -15,6 +15,7 @@ function doPost(e) {
       addRowToSheet: addRowToSheet,
       getSheetRows: getSheetRows,
       createDocument: createDocument,
+      getDocument: getDocument,
       createCalendarEvent: createCalendarEvent,
       markAsRead: markAsRead,
       setLabel: setLabel,

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ curl -X POST "$BASE_URL" \
   -d '{"secret":"'"$SECRET"'","action":"createDocument","title":"Neues Dokument","body":"Inhalt"}'
 ```
 
+### Dokument abrufen
+```bash
+curl -X POST "$BASE_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"secret":"'"$SECRET"'","action":"getDocument","documentId":"DOCUMENT_ID"}'
+```
+
 ### Kalendereintrag erstellen
 ```bash
 curl -X POST "$BASE_URL" \

--- a/docs.gs
+++ b/docs.gs
@@ -10,3 +10,20 @@ function createDocument(params) {
     return { error: err.message };
   }
 }
+
+function getDocument(params) {
+  try {
+    if (!params.documentId) {
+      return { error: 'Missing documentId' };
+    }
+    var doc = DocumentApp.openById(params.documentId);
+    return {
+      documentId: params.documentId,
+      title: doc.getName(),
+      body: doc.getBody().getText(),
+      url: doc.getUrl(),
+    };
+  } catch (err) {
+    return { error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary
- add `getDocument` function for fetching existing Google Docs
- expose `getDocument` through webhook actions map
- document how to request a document via API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b80cc4988329ad48127073425539