### PR TITLE
feat: add Gmail label listing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -19,6 +19,7 @@ function doPost(e) {
       createCalendarEvent: createCalendarEvent,
       markAsRead: markAsRead,
       setLabel: setLabel,
+      getLabels: getLabels,
     };
     var action = payload.action;
     if (!action || !actions[action]) {

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Requests müssen das Feld `secret` und `action` enthalten. Der Rückgabewert ist
   Body `{"secret":"$SECRET","action":"setLabel","query":"from:user@example.com","labelName":"Wichtig","maxResults":5}`
 
 
+### Labels abrufen
+
+  Header: `"Content-Type: application/json"` \
+  Body `{"secret":"$SECRET","action":"getLabels"}`
+
+
 ### Zeile zu Sheet hinzufügen
 
   Header: `"Content-Type: application/json"` \

--- a/email.gs
+++ b/email.gs
@@ -69,3 +69,14 @@ function setLabel(params) {
     return { error: err.message };
   }
 }
+
+function getLabels() {
+  try {
+    var labels = GmailApp.getUserLabels().map(function(label) {
+      return label.getName();
+    });
+    return { labels: labels };
+  } catch (err) {
+    return { error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary
- expose Gmail labels through new `getLabels` action
- document label retrieval in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893d23aa5ac83298e3b70295cc1560f